### PR TITLE
[#1] feat: 프론트 매니페스트 초기 설정

### DIFF
--- a/frontend/deployment.yaml
+++ b/frontend/deployment.yaml
@@ -1,0 +1,32 @@
+﻿apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ipiece-frontend
+  labels:
+    app: ipiece-frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ipiece-frontend
+  template:
+    metadata:
+      labels:
+        app: ipiece-frontend
+    spec:
+      containers:
+        - name: ipiece-frontend
+          # 🔥 이 라인은 GitHub Actions에서 sed로 자동 치환됨
+          image: 235625001959.dkr.ecr.ap-northeast-2.amazonaws.com/ipiece-frontend:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: NODE_ENV
+              value: "production"
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/frontend/kustomization.yaml
+++ b/frontend/kustomization.yaml
@@ -1,0 +1,5 @@
+﻿apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/frontend/service.yaml
+++ b/frontend/service.yaml
@@ -1,0 +1,15 @@
+﻿apiVersion: v1
+kind: Service
+metadata:
+  name: ipiece-frontend
+  labels:
+    app: ipiece-frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: ipiece-frontend
+  ports:
+    - port: 80
+      targetPort: 3000
+      protocol: TCP
+      name: http


### PR DESCRIPTION
## 📌 개요 (Summary)
프론트엔드(Next.js) 애플리케이션을 EKS 환경에 배포하기 위한 GitOps 매니페스트 파일들의 초기 구조를 구성했습니다.

## 🛠 변경 사항 (Changes)
`frontend/` 디렉토리를 생성하고 다음 리소스들을 정의했습니다.

1. **Deployment (`deployment.yaml`)**
   - **Replicas**: 2개 (고가용성 확보)
   - **Image**: AWS ECR (`ipiece-frontend`) 연동 설정
   - **Resources**: 메모리 및 CPU 리밋 설정으로 안정성 확보
   - **Strategy**: CI/CD 파이프라인을 통해 이미지 태그가 자동 교체되도록 구성

2. **Service (`service.yaml`)**
   - **Type**: ClusterIP (내부 통신용)
   - **Port**: 80 (Cluster) → 3000 (Container Target)

3. **Kustomization (`kustomization.yaml`)**
   - ArgoCD 연동을 위한 리소스 통합 관리 설정

## 🔗 관련 이슈 (Issues)
- Resolves #1