### PR TITLE
[#3] feat: argo 매니페스트 초기설정 (프론트)

### DIFF
--- a/argo/ipiece-frontend-app.yaml
+++ b/argo/ipiece-frontend-app.yaml
@@ -1,0 +1,20 @@
+﻿apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ipiece-frontend
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Woori-FISA-Go/ipiece-manifests.git
+    targetRevision: main
+    path: frontend
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ipiece-frontend
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## 📌 Summary

ArgoCD가 `ipiece-manifests` 저장소를 감시하고 EKS 클러스터에 자동 배포(GitOps)를 수행할 수 있도록 **Application CRD** 파일을 추가했습니다.

## ✍️ Description

- `argo/ipiece-frontend-app.yaml` 파일을 생성했습니다.
- **Source**: 현재 저장소(`ipiece-manifests`)의 `frontend` 디렉토리
- **Target Revision**: `develop` 브랜치 (개발 환경 기준)
- **Sync Policy**:
    - `Automated`: 자동 동기화 활성화
    - `Prune`: Git에서 리소스 삭제 시 클러스터에서도 삭제
    - `SelfHeal`: 클러스터 상태가 임의로 변경되면 Git 상태로 자동 복구
- **Destination**: `ipiece-frontend` 네임스페이스 (없을 시 자동 생성 옵션 포함)
- close: #2

## 💡 PR Point

- **Target Revision 설정**: 현재 우리의 Default Branch가 `develop`으로 변경되었기 때문에, ArgoCD가 바라보는 브랜치도 `main`이 아닌 **`develop`*으로 설정했습니다.
- **Namespace 관리**: `SyncOptions`에 `CreateNamespace=true`를 넣어, 배포 시 네임스페이스를 별도로 만들지 않아도 되도록 편의성을 높였습니다.

## 📚 Reference

- [[ArgoCD Declarative Setup](https://www.google.com/search?q=https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/%23application)](https://www.google.com/search?q=https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/%23application)

## 🔥 Test

PR Merge 후 ArgoCD가 설치된 클러스터에서 다음 명령어로 적용 테스트 예정:

Bash

`kubectl apply -f argo/ipiece-frontend-app.yaml`