### PR TITLE
fix: main -> develop로 변경

### DIFF
--- a/argo/ipiece-frontend-app.yaml
+++ b/argo/ipiece-frontend-app.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: ipiece-frontend
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/Woori-FISA-Go/ipiece-manifests.git
-    targetRevision: main
+    targetRevision: develop
     path: frontend
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
## 📌 Summary
ArgoCD가 `ipiece-manifests` 저장소를 감시하고 EKS 클러스터에 자동 배포(GitOps)를 수행할 수 있도록 **Application CRD** 파일을 추가했습니다.

## ✍️ Description
- `argo/ipiece-frontend-app.yaml` 생성
- **Target Revision**: `develop` (개발 환경 기준 적용 완료)
- **Destination**: `ipiece-frontend` 네임스페이스
- **Sync Policy**: Automated (Prune, SelfHeal 활성화)

## 🔗 Issue
- close: #2