### PR TITLE
프론트엔드 ALB Ingress 추가 및 AZ 트래픽 비용 최적화

### DIFF
--- a/frontend/ingress.yaml
+++ b/frontend/ingress.yaml
@@ -1,0 +1,29 @@
+﻿apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ipiece-frontend-ingress
+  namespace: ipiece-frontend
+  annotations:
+    # ⚠️ kubernetes.io/ingress.class annotation 제거 (아래 spec 필드로 대체)
+    
+    # 외부 접속 허용
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    
+    # 파드 IP로 직접 전송 (Topology Aware Routing과 궁합이 가장 좋음)
+    alb.ingress.kubernetes.io/target-type: ip
+    
+    # 헬스체크 경로
+    alb.ingress.kubernetes.io/healthcheck-path: /
+spec:
+  # ✅ 최신 표준: 어노테이션 대신 여기서 ALB를 지정합니다.
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ipiece-frontend
+                port:
+                  number: 80

--- a/frontend/kustomization.yaml
+++ b/frontend/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - ingress.yaml

--- a/frontend/service.yaml
+++ b/frontend/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: ipiece-frontend
   labels:
     app: ipiece-frontend
+  annotations:
+    # 🔥 같은 AZ에 있는 파드에게 우선 트래픽 전송 (AWS 비용 절감 & 속도 향상)
+    service.kubernetes.io/topology-mode: "Auto"
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
## 📌 Summary
프론트엔드 서비스의 외부 접속을 위해 **AWS ALB Ingress**를 추가하고, 가용영역(AZ) 간 데이터 전송 비용을 절감하기 위해 **Topology Aware Routing**을 적용했습니다.

## ✍️ Description
### 1. Ingress 추가 (`frontend/ingress.yaml`)
- **Ingress Class**: 최신 표준인 `spec.ingressClassName: alb` 사용
- **Routing**:
  - `scheme: internet-facing` (외부 접속 허용)
  - `target-type: ip` (ALB가 파드 IP로 직접 트래픽 전송 → Latency 감소)
  - `healthcheck-path: /` (루트 경로 헬스체크)

### 2. Service 최적화 (`frontend/service.yaml`)
- **Topology Mode**: `service.kubernetes.io/topology-mode: "Auto"` 추가
- **효과**: ALB가 트래픽을 보낼 때, 자신과 **같은 AZ에 있는 파드**로 우선 전송하여 Cross-AZ 비용 절감

### 3. Kustomization
- `ingress.yaml` 리소스 등록 완료

## 🔗 Issue
- close: #6