### PR TITLE
[#11] feat: 모니터링 시스템 구축 (Loki S3 연동 + Prometheus EBS 구성)

### DIFF
--- a/system/monitoring/Chart.yaml
+++ b/system/monitoring/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: monitoring
+description: IPiece Monitoring Stack
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+
+dependencies:
+  # 프로메테우스 + 그라파나 통합팩 (Prometheus & Grafana)
+  - name: kube-prometheus-stack
+    version: 61.3.2
+    repository: https://prometheus-community.github.io/helm-charts
+
+  # 로키 로그 수집기 (Loki)
+  - name: loki-stack
+    version: 2.10.2
+    repository: https://grafana.github.io/helm-charts

--- a/system/monitoring/values.yaml
+++ b/system/monitoring/values.yaml
@@ -1,0 +1,98 @@
+# ==========================================
+# 1. Prometheus (메트릭 저장소 - EBS 사용)
+# ==========================================
+kube-prometheus-stack:
+  prometheus:
+    prometheusSpec:
+      # [중요] OTel Collector가 메트릭을 쏠 수 있게 문을 열어둠
+      enableRemoteWriteReceiver: true
+      
+      # 데이터 보관 주기 (15일)
+      retention: 15d
+      
+      # EBS gp3 50GB 사용 (월 5천원 수준)
+      storageSpec:
+        volumeClaimTemplate:
+          spec:
+            storageClassName: gp3
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: 50Gi
+      
+      # 메모리 리소스 제한
+      resources:
+        requests:
+          memory: 1Gi
+        limits:
+          memory: 2Gi
+
+  # 그라파나 (시각화 도구)
+  grafana:
+    enabled: true
+    adminPassword: "admin" # 초기 비번 (로그인 후 변경 권장)
+    persistence:
+      enabled: true
+      storageClassName: gp3
+      size: 10Gi
+    
+    # Loki를 데이터 소스로 자동 추가
+    additionalDataSources:
+      - name: Loki
+        type: loki
+        url: http://ipiece-monitoring-loki:3100/
+        access: proxy
+
+# ==========================================
+# 2. Loki (로그 저장소 - S3 사용)
+# ==========================================
+loki-stack:
+  # [중요] OTel Collector를 사용할 것이므로 기본 수집기(Promtail)는 끕니다.
+  promtail:
+    enabled: false
+
+  loki:
+    enabled: true
+    isDefault: false
+    config:
+      auth_enabled: false
+      
+      # S3 저장 구조 설정
+      schema_config:
+        configs:
+          - from: 2024-01-01
+            store: boltdb-shipper
+            object_store: s3
+            schema: v11
+            index:
+              prefix: index_
+              period: 24h
+      
+      # AWS S3 버킷 연결
+      storage_config:
+        aws:
+          s3: s3://ap-northeast-2/ipiece-loki-store
+          region: ap-northeast-2
+
+    # [보안] S3 접근 키 설정 (Kubernetes Secret에서 가져옴)
+    extraEnv:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: loki-s3-secret
+            key: S3_AWS_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: loki-s3-secret
+            key: S3_AWS_SECRET_ACCESS_KEY
+
+    # 오래된 로그 정리 (Compactor)
+    compactor:
+      working_directory: /data/loki/boltdb-shipper-compactor
+      shared_store: s3
+      retention_enabled: true
+    
+    # 30일 지난 로그 자동 삭제
+    limits_config:
+      retention_period: 30d


### PR DESCRIPTION
## 📌 작업 목적
- 컨테이너 로그의 장기 보관을 위해 **Loki와 AWS S3**를 연동합니다.
- 메트릭 데이터의 영속성을 위해 **Prometheus에 EBS 볼륨**을 할당합니다.
- 추후 OpenTelemetry 도입을 위해 수집 경로를 최적화합니다.

## 🛠️ 주요 변경 사항
### 1. `Chart.yaml`
- `kube-prometheus-stack` (Prometheus + Grafana) 추가
- `loki-stack` (Loki) 추가

### 2. `values.yaml`
- **Prometheus**:
  - EBS gp3 50GB 할당 (Retention 15일)
  - `enableRemoteWriteReceiver: true` 설정 (OTel 연동 준비)
- **Loki**:
  - AWS S3 (`ipiece-loki-store`)를 스토리지로 설정
  - 보안을 위해 Access Key를 **Kubernetes Secret**(`loki-s3-secret`)에서 가져오도록 변경
  - 기본 수집기(`promtail`) 비활성화 (OTel 대체 예정)
- **Grafana**:
  - Loki를 데이터 소스로 자동 등록

## 🔗 관련 이슈
Closes #11