### PR TITLE
[#15] feat: 백엔드 dev/prod 환경 분리 구조 추가

### DIFF
--- a/argo-apps/ipiece-backend-dev.yaml
+++ b/argo-apps/ipiece-backend-dev.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ipiece-backend-dev    # 이름 변경
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Woori-FISA-Go/ipiece-manifests
+    targetRevision: develop
+    path: apps/backend/overlays/dev   # ✅ Dev 폴더 바라보기
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default        # (주의) Prod랑 같은 곳에 뜨면 덮어씌워질 수 있음
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argo-apps/ipiece-backend-prod.yaml
+++ b/argo-apps/ipiece-backend-prod.yaml
@@ -1,27 +1,20 @@
-﻿apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ipiece-backend
+  name: ipiece-backend-prod   # 이름 변경
   namespace: argocd
 spec:
   project: default
   source:
     repoURL: https://github.com/Woori-FISA-Go/ipiece-manifests
     targetRevision: develop
-    path: apps/backend/overlays/dev
+    path: apps/backend/overlays/prod  # ✅ 중요: Prod 폴더 바라보기
   destination:
     server: https://kubernetes.default.svc
-    namespace: default
+    namespace: default        # 운영은 default 네임스페이스 사용
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
-      allowEmpty: false
     syncOptions:
     - CreateNamespace=true
-    retry:
-      limit: 5
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 3m


### PR DESCRIPTION
## 📌 Summary
백엔드의 `dev` / `prod` 환경을 분리하여 ArgoCD가 각 환경을 독립적으로 배포하도록 설정했습니다.  
이 수정은 백엔드 환경별 배포 안정성과 운영 가시성을 강화하는 목적을 갖습니다.

## ✍️ Description
- close: #15
- `argo-apps/ipiece-backend-dev.yaml` 추가  
  → ArgoCD에서 dev 환경을 `apps/backend/overlays/dev` 경로로 배포하도록 신규 Application 생성
- `argo-apps/ipiece-backend-app.yaml` → `argo-apps/ipiece-backend-prod.yaml` 이름 변경  
- prod 환경 Application의 manifest 경로를 `apps/backend/overlays/prod`로 변경
- dev/prod 충돌을 피하기 위해 Application 이름 명확히 분리
- `syncPolicy` 정리 및 prod 환경에 필요한 옵션만 유지

## 💡 PR Point
- dev와 prod가 동일 namespace(`default`)로 배포될 경우 충돌 우려가 있으므로  
  — 필요 시 dev용 별도 네임스페이스(e.g., `ipiece-dev`) 생성 고려 필요  
- prod에서 `allowEmpty: false` 옵션은 빈 manifest 반영 방지 목적이며 유지함  
- dev 환경은 빠른 개발용, prod는 안정성 우선 구조로 구분됨

## 📚 Reference
- GitOps Best Practice: Environment Overlay 분리  
- ArgoCD Official Docs – Application CRD  
  https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/

## 🔥 Test
- ArgoCD에서 dev / prod 두 Application이 분리되어 인식되는지 확인  
- dev → prod 오염 없는지 path 및 namespace 검증  
- sync 정상 동작 여부 확인
