### PR TITLE
[#19]fix: 백엔드 prod, ALB healthcheck 통일

### DIFF
--- a/apps/backend/base/ingress.yaml
+++ b/apps/backend/base/ingress.yaml
@@ -1,30 +1,30 @@
-apiVersion: networking.k8s.io/v1
+﻿apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ipiece-backend-ingress
   annotations:
-    # 외부에서 접근 가능한 ALB
+    # ?몃??먯꽌 ?묎렐 媛?ν븳 ALB
     alb.ingress.kubernetes.io/scheme: internet-facing
 
-    # 파드 IP로 직접 전송
+    # ?뚮뱶 IP濡?吏곸젒 ?꾩넚
     alb.ingress.kubernetes.io/target-type: ip
 
-    # 프론트와 같은 ALB를 공유하기 위한 그룹 이름
+    # ?꾨줎?몄? 媛숈? ALB瑜?怨듭쑀?섍린 ?꾪븳 洹몃９ ?대쫫
     alb.ingress.kubernetes.io/group.name: ipiece
 
-    # 백엔드 헬스체크 엔드포인트
-    alb.ingress.kubernetes.io/healthcheck-path: /healthz
+    # 諛깆뿏???ъ뒪泥댄겕 ?붾뱶?ъ씤??
+    alb.ingress.kubernetes.io/healthcheck-path: /api/healthz
 spec:
-  # ALB IngressClass 사용
+  # ALB IngressClass ?ъ슜
   ingressClassName: alb
   rules:
     - http:
         paths:
-          # 브라우저에서 /api/** 로 오는 요청을 백엔드로 보냄
+          # 釉뚮씪?곗??먯꽌 /api/** 濡??ㅻ뒗 ?붿껌??諛깆뿏?쒕줈 蹂대깂
           - path: /api/
             pathType: Prefix
             backend:
               service:
-                name: ipiece-server  # ← service.yaml 의 metadata.name 과 동일
+                name: ipiece-server  # ??service.yaml ??metadata.name 怨??숈씪
                 port:
-                  number: 80         # ← service.yaml 의 spec.ports[0].port 와 동일
+                  number: 80         # ??service.yaml ??spec.ports[0].port ? ?숈씪

--- a/apps/backend/overlays/prod/kustomization.yaml
+++ b/apps/backend/overlays/prod/kustomization.yaml
@@ -1,4 +1,4 @@
-kind: Kustomization
+﻿kind: Kustomization
 
 resources:
 - ../../base
@@ -10,7 +10,7 @@ patches:
       value: 2
   target:
     kind: Deployment
-    name: ipiece-backend
+    name: ipiece-server
 apiVersion: kustomize.config.k8s.io/v1beta1
 images:
 - name: 235625001959.dkr.ecr.ap-northeast-2.amazonaws.com/ipiece-server


### PR DESCRIPTION
## 📌 Summary
백엔드 Prod Kustomize 오버레이와 ALB 헬스체크 경로를 정리하여, 환경별 설정이 의도대로 동작하고 헬스체크 경로가 일관되도록 수정했습니다.

## ✍️ Description
- close: #19

### 변경 내용
1. `apps/backend/overlays/prod/kustomization.yaml`
   - `patches.target.name`을 `ipiece-backend` → `ipiece-server` 로 수정
   - 실제 Deployment 리소스 이름과 일치하도록 하여 prod 환경에서 `replicas: 2` 패치가 정상적으로 적용되도록 함

2. `apps/backend/base/ingress.yaml`
   - `alb.ingress.kubernetes.io/healthcheck-path` 값을 `/healthz` → `/api/healthz` 로 변경
   - 애플리케이션 컨텍스트(`/api`)와 K8s liveness/readinessProbe 경로(`/api/healthz`)에 맞게 ALB 헬스체크 경로를 통일

## 💡 PR Point
- prod 오버레이의 타겟 이름 불일치로 인해 Kustomize 패치가 실제로는 적용되지 않던 잠재 이슈를 제거했습니다.
- ALB Target Group 헬스체크 경로를 애플리케이션/쿠버네티스 프로브와 동일하게 맞춰, 운영/디버깅 시 헷갈릴 수 있는 부분을 줄였습니다.
- 현재 동작에는 문제가 없었지만, 향후 base/overlays 분리 운영 시 의도와 다르게 동작할 수 있는 부분을 사전에 정리하는 성격의 PR입니다.

## 📚 Reference 
- `apps/backend/base/deployment.yaml` (SERVER_SERVLET_CONTEXT_PATH, /api/healthz probes)
- `apps/backend/base/ingress.yaml`
- `apps/backend/overlays/prod/kustomization.yaml`

## 🔥 Test
- [ ] `kubectl kustomize apps/backend/overlays/prod` 결과에서 `Deployment/ipiece-server`의 `spec.replicas: 2` 확인
- [ ] `kubectl describe ingress ipiece-backend-ingress -n default`에서 `healthcheck-path: /api/healthz` 확인
- [ ] ArgoCD `ipiece-backend-prod` Sync 후 Status: Synced & Healthy 확인
- [ ] AWS Target Group(`k8s-default-ipiecese-...`) Health check path가 `/api/healthz`로 반영되었는지 확인
- [ ] `http(s)://<ALB DNS>/api/healthz` 호출 시 200 OK 응답 확인
