### PR TITLE
[#26] feat: S3 자격증명 전환

### DIFF
--- a/apps/backend/base/deployment.yaml
+++ b/apps/backend/base/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: ipiece-server
     spec:
+      serviceAccountName: ipiece-backend-sa # S3 접근을 위한 추가
       imagePullSecrets:
       - name: ecr-secret
       containers:

--- a/apps/backend/overlays/prod/ServiceAccount.yaml
+++ b/apps/backend/overlays/prod/ServiceAccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ipiece-backend-sa
+  namespace: default
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::235625001959:oidc-provider/oidc.eks.ap-northeast-2.amazonaws.com/id/85741B40F2E009117BEA572204C26FE3

--- a/apps/backend/overlays/prod/kustomization.yaml
+++ b/apps/backend/overlays/prod/kustomization.yaml
@@ -1,6 +1,7 @@
 
 resources:
 - ../../base
+- serviceaccount.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 images:


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
### S3 자격증명 방식 전환


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
### 기존
- application.yml, .env로 "AWS_ACCESS_KEY"와 "AWS_SECRET_KEY"를 설정
- 백엔드 컨테이너가 정적 credential로 S3에 접근
- 문제점 : 키 유출 리스크로 파일을 푸쉬할 수 없음

### 변경
- EKS 클러스터의 OIDC Provider + IRSA(IAM Role for ServiceAccount)를 사용
- 'ipiece-backend-sa' ServiceAccount를 생성하고 IAM role과 연결
- Deployment에 해당 ServiceAccount 지정
- 애플리케이션코드는 ServiceAccount에 연결된 IAM role을 통해 S3에 접근
- close: #26 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
테스트는 실제 배포 후 적용을 확인한다.
